### PR TITLE
Second argument didn't get parsed correctly with old syntax. Fixed.

### DIFF
--- a/red-light-therapy-dose-calculator.py
+++ b/red-light-therapy-dose-calculator.py
@@ -10,8 +10,8 @@ import argparse
 import sys
 
 parser = argparse.ArgumentParser(description='Dose calculator for red light therapy.')
-parser.add_argument('watts', metavar='WATTS', type=int, default=160, nargs='?', help='Watts Per Squared Meter')
-parser.add_argument('seconds', metavar='SECONDS', type=int, default=60, nargs='?', help='Seconds Per 45 Degree Round')
+parser.add_argument('--watts', metavar='WATTS', type=int, default=160, nargs='?', help='Watts Per Squared Meter')
+parser.add_argument('--seconds', metavar='SECONDS', type=int, default=60, nargs='?', help='Seconds Per 45 Degree Round')
 
 args, unknown = parser.parse_known_args()
 # PyCharm: ignore extra arguments in interactive mode.


### PR DESCRIPTION
When I tried the code on Windows using Python 3.6.5 it didn't correctly parse the second argument "seconds". It always got the default 60 no matter what I wrote. Switching to prefoxing the arguments with "--" fixed that and both arguments gets parsed correctly. 